### PR TITLE
Added ability to specify XmlReader flags

### DIFF
--- a/lib/Reader.php
+++ b/lib/Reader.php
@@ -235,7 +235,7 @@ class Reader implements Iterator
             $this->worksheet_reader->setDefaultNamespaceIdentifierAttributes(OoxmlReader::NS_NONE);
         }
 
-        $this->worksheet_reader->open($this->worksheet_path);
+        $this->worksheet_reader->open($this->worksheet_path, null, $this->configuration->getReaderFlags());
 
         // Reset read-relevant internal variables to their initial values to avoid conflicts between subsequent rewinds.
         $this->reader_points_at_new_row = false;

--- a/lib/ReaderConfiguration.php
+++ b/lib/ReaderConfiguration.php
@@ -99,6 +99,13 @@ class ReaderConfiguration
      */
     private $return_date_time_objects = false;
 
+    /**
+     * Sets the flags that will be passed to XmlReader::open.
+     *
+     * @var int
+     */
+    private $reader_flags = 0;
+
     public function __construct()
     {
         $this->temp_dir = sys_get_temp_dir();
@@ -295,6 +302,19 @@ class ReaderConfiguration
     }
 
     /**
+     * Sets the flags that will be passed to XmlReader::open.
+     *
+     * @param  int $flags
+     * @return self
+     */
+    public function setReaderFlags(int $flags): self
+    {
+        $this->reader_flags = $flags;
+
+        return $this;
+    }
+
+    /**
      * @return string
      */
     public function getTempDir(): string
@@ -388,5 +408,13 @@ class ReaderConfiguration
     public function getReturnDateTimeObjects(): bool
     {
         return $this->return_date_time_objects;
+    }
+
+    /**
+     * @return int
+     */
+    public function getReaderFlags(): bool
+    {
+        return $this->reader_flags;
     }
 }


### PR DESCRIPTION
Hi there,

I've encountered an issue where my XLSX file is huge and throws a "Huge input lookup" error.

Passing `LIBXML_PARSEHUGE` to `XmlReader::open` disabled the check and allows it to continue however it's not possible to set the `XmlReader::open` flags.

I haven't written any tests for this as it will involve supplying a spreadsheet that throws the error which is difficult.

If you want me to make any changes, or add tests, please let me know.